### PR TITLE
ignore unknown chrome output, like internal errors, warnings, etc.

### DIFF
--- a/src/core/chrome.nim
+++ b/src/core/chrome.nim
@@ -93,9 +93,7 @@ proc startChrome*(portNo: int; userDataDir: string; headless: HeadlessMode;
                 "note: you can leave your normal browser window/session alone.")
         elif line == "": continue
         else:
-            process.terminate()
-            process.close()
-            raise newException(ProcessError, "unexpected output from Chrome: " & line)
+            discard
     if result.cdpEndPoint == "":
         if process.running():
             process.terminate()


### PR DESCRIPTION
I've seen two kinds of error messages that are not expected. but still works fine.
![image2](https://github.com/Niminem/ChromeDevToolsProtocol/assets/2238294/65f13c88-4ad8-4117-a918-2bac2f87fc10)
